### PR TITLE
Schema#execute supports JSON::Any params

### DIFF
--- a/spec/graphql-crystal/schema_spec.cr
+++ b/spec/graphql-crystal/schema_spec.cr
@@ -205,6 +205,22 @@ describe GraphQL::Schema do
       })
     end
 
+    it "answers a request with non-nullable arg and arg provided with JSON::Any type" do
+      TestSchema::Schema.execute(
+        "query getAddresses($city: [City]!) { addresses(city: $city) { city } }", JSON.parse({
+          "city" => [
+            "London"
+          ]
+        }.to_json)
+      ).should eq({
+        "data" => {
+          "addresses" => [
+            {"city" => "London"}
+          ],
+        }
+      })
+    end
+
     it "raises if non-nullable args ommited" do
       TestSchema::Schema.execute(
         "query getAddresses($city: [City]!) { addresses(city: $city) { city } }"


### PR DESCRIPTION
We usually got params from HTTP body and parse it to `JSON::Any` type, supports it is very useful.

I can call it by:

```crystal
class GraphQLController < Amber::Controller::Base
  def execute
    result = BackendSchema.schema.execute(params[:query], JSON.parse(params[:variables]))
    respond_with do
      json result.to_json
    end
  end
end
```