### PR TITLE
rebased to master: field :x now expands to 'private def field_x'

### DIFF
--- a/spec/graphql-crystal/support/go_graphql_test_schema_spec.cr
+++ b/spec/graphql-crystal/support/go_graphql_test_schema_spec.cr
@@ -4,30 +4,30 @@ describe GO_GRAPHQL_TEST_SCHEMA do
   it "parses the complex query that was used by the go-graphql benchmark" do
     query = %{
       query Example($size: Int) {
-      	a,
-      	b,
-      	x: c
-      	...c
-      	f
-      	...on DataType {
-      	  pic(size: $size)
-      	  promise {
-      	    a
-      	  }
-      	}
-      	deep {
-      	  a
-      	  b
-      	  c
-      	  deeper {
-      	    a
-      	    b
-      	  }
-      	}
+        A,
+        b,
+        x: c
+        ...c
+        f
+        ...on DataType {
+          Pic(size: $size)
+          promise {
+            A
+          }
+        }
+        deep {
+          A
+          b
+          c
+          deeper {
+            A
+            b
+          }
+        }
       }
       fragment c on DataType {
-      	d
-      	e
+        d
+        e
       }
     }
 
@@ -35,18 +35,18 @@ describe GO_GRAPHQL_TEST_SCHEMA do
       %{
          {
            "data": {
-             "a": "Apple",
+             "A": "Apple",
              "b": "Banana",
              "x": "Cookie",
              "d": "Donut",
              "e": "Egg",
              "f": "Fish",
-             "pic": "Pic of size: 50",
+             "Pic": "Pic of size: 50",
              "promise": {
-                 "a": "Apple"
+                 "A": "Apple"
                },
              "deep": {
-               "a": "Already Been Done",
+               "A": "Already Been Done",
                "b": "Boring",
                "c": [
                      "Contrived",
@@ -54,10 +54,10 @@ describe GO_GRAPHQL_TEST_SCHEMA do
                      "Confusing"
                    ],
                "deeper": [{
-                            "a": "Already Been Done",
+                            "A": "Already Been Done",
                             "b": "Boring"
                           },{
-                            "a": "Already Been Done",
+                            "A": "Already Been Done",
                             "b": "Boring"
                           }]
              }

--- a/spec/support/go_graphql_test_schema.cr
+++ b/spec/support/go_graphql_test_schema.cr
@@ -1,13 +1,13 @@
 module DataType
   include ::GraphQL::ObjectType
   extend self
-  field :a { "Apple" }
+  field :A { "Apple" }
   field :b { "Banana" }
   field :c { "Cookie" }
   field :d { "Donut" }
   field :e { "Egg" }
   field :f { "Fish" }
-  field :pic { |args| "Pic of size: #{args["size"]? || 50}" }
+  field :Pic { |args| "Pic of size: #{args["size"]? || 50}" }
   field :deep { DeepDataType }
   field :promise { DataType }
 end
@@ -15,7 +15,7 @@ end
 module DeepDataType
   include ::GraphQL::ObjectType
   extend self
-  field :a { "Already Been Done" }
+  field :A { "Already Been Done" }
   field :b { "Boring" }
   field :c { ["Contrived", nil, "Confusing"] }
   field :deeper { [self, self] }
@@ -28,19 +28,19 @@ GO_GRAPHQL_TEST_SCHEMA = ::GraphQL::Schema.from_schema(
     }
 
     type DataType {
-      a: String
+      A: String
       b: String
       c: String
       d: String
       e: String
       f: String
-      pic(size: Int): String
+      Pic(size: Int): String
       deep: DeepDataType
       promise: DataType
     }
 
     type DeepDataType {
-      a: String
+      A: String
       b: String
       c: [String]
       deeper: [DeepDataType]

--- a/src/graphql-crystal/types/object_type.cr
+++ b/src/graphql-crystal/types/object_type.cr
@@ -32,7 +32,7 @@ macro on_included
 
       macro field(name, description, args, typename, &block)
         \\{% GRAPHQL_FIELDS << {name, description, args, typename} %}
-        private def \\{{name.id}}_field(\\{{(block.is_a?(Block) && block.args.size > 0) ? block.args.first.id : args}}, \\{{((block.is_a?(Block) && block.args.size > 1) ? block.args[1].id : "context").id}})
+        private def field_\\{{name.id}}(\\{{(block.is_a?(Block) && block.args.size > 0) ? block.args.first.id : args}}, \\{{((block.is_a?(Block) && block.args.size > 1) ? block.args[1].id : "context").id}})
           \\{% if block.is_a?(Block) %}
               context.with_self(\\{{(block.is_a?(Block) && block.args.size > 0) ? block.args.first.id : args}}) do
                 \\{{block.body}}
@@ -59,7 +59,7 @@ macro on_included
               case name
                   \\{% for field in @type.constant("GRAPHQL_FIELDS") %}
                     when "\\{{ field[0].id }}" #\\\\\{{@type}}
-                      \\{{field[0].id}}_field(arguments, context)
+                      field_\\{{field[0].id}}(arguments, context)
                       \\{% end %}
               else
                 \\{% if prev_def.is_a?(Def) %}


### PR DESCRIPTION
Previously it was expanding into 'private def x_field', which,
if x was a word starting with uppercase, was causing a syntax
error.

This change now allows creating fields with first letter in
uppercase.