### PR TITLE
Fix casting Hash(String, JSON::Any) to JSONType

### DIFF
--- a/spec/graphql-crystal/schema/variables_spec.cr
+++ b/spec/graphql-crystal/schema/variables_spec.cr
@@ -1,0 +1,34 @@
+# coding: utf-8
+require "../../spec_helper"
+
+describe GraphQL::Schema, "using variables" do
+
+  # When used in conjunction with Kemal as web framework, query variables
+  # exposed by Kemal are of type Hash(String, JSON::Any). These should be able
+  # to be parsed correctly.
+  it "accepts query variables as Hash(String, JSON::Any)" do
+    context = CustomContext.new({authenticated: true, name: "Anon"}, CUSTOM_CONTEXT_SCHEMA, nil)
+
+    mutation = %{
+      mutation addLog($input: LogInput!) {
+        log(log: $input) {
+          time
+        }
+      }
+    }
+    json_any = JSON.parse({ time: "now",
+                            hostName: "docker host",
+                            process: {
+                              name: "crystal spec",
+                              pid: 42
+                            },
+                            message: "in a bottle" }.to_json)
+    variables = { "input" => json_any }
+    variables.class.should eq Hash(String, JSON::Any)
+
+    CUSTOM_CONTEXT_SCHEMA.execute(mutation, params: variables, context: context).should eq(
+      { "data" => { "log" => { "time" => "now" } } }
+    )
+  end
+
+end

--- a/src/graphql-crystal/schema/schema_execute.cr
+++ b/src/graphql-crystal/schema/schema_execute.cr
@@ -522,6 +522,8 @@ module GraphQL
             hash[key] = cast_to_jsontype(v[key])
             hash
           end
+        when JSON::Any
+          cast_jsonany_to_jsontype(v)
         else
           v
         end.as(JSONType)

--- a/src/graphql-crystal/schema/schema_execute.cr
+++ b/src/graphql-crystal/schema/schema_execute.cr
@@ -504,7 +504,7 @@ module GraphQL
             hash[key] = cast_jsonany_to_jsontype(raw[key])
             hash
           end
-        else 
+        else
           raw
         end
       end


### PR DESCRIPTION
When used in conjunction with Kemal as web framework, the GraphQL query variables exposed by Kemal are of type `Hash(String, JSON::Any)`. As is the case in https://github.com/ziprandom/kemal-graphql-example.

This change employs an already existing method to ensure the `Hash(String, JSON::Any)` type can be successfully cast to `JSONType`.

Inspired by an initial fix by @hberntsen.