### PR TITLE
Remove support for crystal < 0.25.0

### DIFF
--- a/src/graphql-crystal/schema/schema_execute.cr
+++ b/src/graphql-crystal/schema/schema_execute.cr
@@ -9,11 +9,7 @@ module GraphQL
         description: "the name of this GraphQL type"
       )
 
-      {% if compare_versions(Crystal::VERSION, "0.25.0") < 0 %}
-        alias JSONType = JSON::Type
-      {% else %}
-        alias JSONType = Nil | Bool | Int64 | Float64 | String | Array(JSONType) | Hash(String, JSONType)
-      {% end %}
+      alias JSONType = Nil | Bool | Int64 | Float64 | String | Array(JSONType) | Hash(String, JSONType)
       alias ExecuteParams = Hash(String, JSONType) | Hash(String, String | Hash(String, JSONType | Nil))
 
       #


### PR DESCRIPTION
The current implementation is already broken for these versions.

```
Syntax error in lib/msgpack/src/message_pack/serializable.cr:282: expecting token ']', not '::'

      @[MessagePack::Field(ignore: true)]
```